### PR TITLE
feat: Added option to not use account lifecycle events to trigger the AWS Permission Set pipeline

### DIFF
--- a/modules/iam/permission-set-pipeline/data.tf
+++ b/modules/iam/permission-set-pipeline/data.tf
@@ -1,7 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-data "aws_organizations_organization" "org" {}
+data "aws_organizations_organization" "org" {
+  count = var.account_lifecycle_events_source == "CT" ? 1 : 0
+}
 
 data "aws_ssoadmin_instances" "sso" {}
 
@@ -14,21 +16,21 @@ data "local_file" "buildspec" {
 }
 
 data "archive_file" "aft_new_account_event_forwarder" {
-  count       = var.account_lifecyle_events_source == "AFT" ? 1 : 0
+  count       = var.account_lifecycle_events_source == "AFT" ? 1 : 0
   type        = "zip"
   source_dir  = "${path.module}/lambda/aft-new-account-event-forwarder"
   output_path = "${path.module}/lambda/aft-new-account-event-forwarder.zip"
 }
 
 data "aws_ssm_parameter" "aft_sns_notification_topic_arn" {
-  count    = var.account_lifecyle_events_source == "AFT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "AFT" ? 1 : 0
   provider = aws.event-source-account
 
   name = "/aft/account/aft-management/sns/topic-arn"
 }
 
 data "aws_ssm_parameter" "aft_management_account_id" {
-  count    = var.account_lifecyle_events_source == "AFT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "AFT" ? 1 : 0
   provider = aws.event-source-account
 
   name = "/aft/account/aft-management/account-id"

--- a/modules/iam/permission-set-pipeline/events.tf
+++ b/modules/iam/permission-set-pipeline/events.tf
@@ -2,19 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 resource "aws_cloudwatch_event_bus" "pipeline" {
+  count = var.account_lifecycle_events_source != "None" ? 1 : 0
+
   name = "${var.solution_name}-event-bus"
 }
 
 resource "aws_cloudwatch_event_permission" "pipeline" {
-  event_bus_name = aws_cloudwatch_event_bus.pipeline.name
+  count = var.account_lifecycle_events_source != "None" ? 1 : 0
+
+  event_bus_name = aws_cloudwatch_event_bus.pipeline[0].name
   principal      = local.event_rule_account_id
   statement_id   = "SourceEventAccountAccess"
 }
 
 resource "aws_cloudwatch_event_rule" "pipeline" {
+  count = var.account_lifecycle_events_source != "None" ? 1 : 0
+
   name           = "${var.solution_name}-controltower-events"
   description    = "Capture Control Tower events to start the permission set pipeline"
-  event_bus_name = aws_cloudwatch_event_bus.pipeline.name
+  event_bus_name = aws_cloudwatch_event_bus.pipeline[0].name
   event_pattern = jsonencode({
     "account" : [local.event_rule_account_id]
     }
@@ -22,14 +28,16 @@ resource "aws_cloudwatch_event_rule" "pipeline" {
 }
 
 resource "aws_cloudwatch_event_target" "pipeline" {
-  event_bus_name = aws_cloudwatch_event_bus.pipeline.name
-  rule           = aws_cloudwatch_event_rule.pipeline.name
+  count = var.account_lifecycle_events_source != "None" ? 1 : 0
+
+  event_bus_name = aws_cloudwatch_event_bus.pipeline[0].name
+  rule           = aws_cloudwatch_event_rule.pipeline[0].name
   role_arn       = aws_iam_role.start_pipeline.arn
   arn            = aws_codepipeline.main.arn
 }
 
 resource "aws_cloudwatch_event_rule" "ct_events" {
-  count    = var.account_lifecyle_events_source == "CT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "CT" ? 1 : 0
   provider = aws.event-source-account
 
   name        = "${var.solution_name}-ct-events"
@@ -46,16 +54,16 @@ resource "aws_cloudwatch_event_rule" "ct_events" {
 }
 
 resource "aws_cloudwatch_event_target" "ct_events" {
-  count    = var.account_lifecyle_events_source == "CT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "CT" ? 1 : 0
   provider = aws.event-source-account
 
   rule     = aws_cloudwatch_event_rule.ct_events[0].name
   role_arn = aws_iam_role.ct_events[0].arn
-  arn      = aws_cloudwatch_event_bus.pipeline.arn
+  arn      = aws_cloudwatch_event_bus.pipeline[0].arn
 }
 
 resource "aws_iam_role" "ct_events" {
-  count    = var.account_lifecyle_events_source == "CT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "CT" ? 1 : 0
   provider = aws.event-source-account
 
   name_prefix        = "${var.solution_name}-ct-events"
@@ -63,7 +71,7 @@ resource "aws_iam_role" "ct_events" {
 }
 
 resource "aws_iam_role_policy" "ct_events" {
-  count    = var.account_lifecyle_events_source == "CT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "CT" ? 1 : 0
   provider = aws.event-source-account
 
   name = "PutEventsPermission"
@@ -75,7 +83,7 @@ resource "aws_iam_role_policy" "ct_events" {
         {
           Action   = ["events:PutEvents"]
           Effect   = "Allow"
-          Resource = aws_cloudwatch_event_bus.pipeline.arn
+          Resource = aws_cloudwatch_event_bus.pipeline[0].arn
         }
       ]
     }

--- a/modules/iam/permission-set-pipeline/iam.tf
+++ b/modules/iam/permission-set-pipeline/iam.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy" "codepipeline_policy" {
 }
 
 resource "aws_iam_role" "lambda" {
-  count    = var.account_lifecyle_events_source == "AFT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "AFT" ? 1 : 0
   provider = aws.event-source-account
 
   name                  = "${var.solution_name}-lambda-role"
@@ -75,7 +75,7 @@ resource "aws_iam_role" "lambda" {
 }
 
 resource "aws_iam_role_policy" "lambda_policy" {
-  count    = var.account_lifecyle_events_source == "AFT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "AFT" ? 1 : 0
   provider = aws.event-source-account
 
   name = "${var.solution_name}-lambda-policy"
@@ -83,6 +83,6 @@ resource "aws_iam_role_policy" "lambda_policy" {
   policy = templatefile("${path.module}/assets/role-policies/lambda_role_policy.json", {
     region        = data.aws_region.current.name
     account_id    = data.aws_ssm_parameter.aft_management_account_id[0].value
-    event_bus_arn = aws_cloudwatch_event_bus.pipeline.arn
+    event_bus_arn = aws_cloudwatch_event_bus.pipeline[0].arn
   })
 }

--- a/modules/iam/permission-set-pipeline/lambda.tf
+++ b/modules/iam/permission-set-pipeline/lambda.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "aft_new_account_event_forwarder" {
   # checkov:skip=CKV_AWS_117:This is a full serveless function doesn't need VPC
   # checkov:skip=CKV_AWS_173:This parameter is not a SecureString and there is no need to encrypt
   # checkov:skip=CKV_AWS_272:This function doesn't need to validate code-signing
-  count    = var.account_lifecyle_events_source == "AFT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "AFT" ? 1 : 0
   provider = aws.event-source-account
 
   filename                       = "${path.module}/lambda/aft-new-account-event-forwarder.zip"
@@ -23,13 +23,13 @@ resource "aws_lambda_function" "aft_new_account_event_forwarder" {
   layers                         = []
   environment {
     variables = {
-      EVENT_BUS_ARN = aws_cloudwatch_event_bus.pipeline.arn
+      EVENT_BUS_ARN = aws_cloudwatch_event_bus.pipeline[0].arn
     }
   }
 }
 
 resource "aws_lambda_permission" "aft_new_account_event_forwarder" {
-  count    = var.account_lifecyle_events_source == "AFT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "AFT" ? 1 : 0
   provider = aws.event-source-account
 
   statement_id  = "AllowExecutionFromSNS"
@@ -40,7 +40,7 @@ resource "aws_lambda_permission" "aft_new_account_event_forwarder" {
 }
 
 resource "aws_sns_topic_subscription" "aft_new_account_event_forwarder" {
-  count    = var.account_lifecyle_events_source == "AFT" ? 1 : 0
+  count    = var.account_lifecycle_events_source == "AFT" ? 1 : 0
   provider = aws.event-source-account
 
   topic_arn           = data.aws_ssm_parameter.aft_sns_notification_topic_arn[0].value

--- a/modules/iam/permission-set-pipeline/locals.tf
+++ b/modules/iam/permission-set-pipeline/locals.tf
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 locals {
-  event_rule_account_id = var.account_lifecyle_events_source == "CT" ? data.aws_organizations_organization.org.master_account_id : data.aws_ssm_parameter.aft_management_account_id[0].value
+  event_rule_account_id = var.account_lifecycle_events_source == "CT" ? data.aws_organizations_organization.org[0].master_account_id : (var.account_lifecycle_events_source == "AFT" ? data.aws_ssm_parameter.aft_management_account_id[0].value : null)
 }

--- a/modules/iam/permission-set-pipeline/variables.tf
+++ b/modules/iam/permission-set-pipeline/variables.tf
@@ -41,13 +41,38 @@ variable "code_connection_provider" {
   }
 }
 
-variable "account_lifecyle_events_source" {
-  description = "Define from where to capture account lifecycle events: AFT or Control Tower (CT)."
+variable "account_lifecycle_events_source" {
+  description = <<-EOF
+    Define from where to capture account lifecycle events: AFT, Control Tower (CT) or None.
+    Based on this choice, you also must change the provider for the source account (aws.event-source-account).
+    For exemple:
+
+      - For AFT as the source account, inform the provider with access to AFT management account:
+        ```
+          providers = {
+            aws.event-source-account = aws.aft-management
+          }
+        ```
+
+      - For CT as the source account, inform the provider with access to CT management account:
+        ```
+          providers = {
+            aws.event-source-account = aws.org-management
+          }
+        ```
+
+      - If you don't want to use account lifecyle events to trigger the pipeline, select None and inform the aws default provider:
+        ```
+          providers = {
+            aws.event-source-account = aws
+          }
+    ```
+  EOF
   type        = string
-  default     = "AFT"
+  default     = "None"
   validation {
-    condition     = contains(["AFT", "CT"], var.account_lifecyle_events_source)
-    error_message = "Valid values for account_lifecyle_events_source are: AFT or CT"
+    condition     = contains(["AFT", "CT", "None"], var.account_lifecycle_events_source)
+    error_message = "Valid values for account_lifecycle_events_source are: AFT, CT or None"
   }
 }
 

--- a/patterns/multi-region-advanced/aft-account-customizations/IDENTITY/terraform/main.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/IDENTITY/terraform/main.tf
@@ -35,11 +35,11 @@ module "aws_ps_pipeline" {
   }
   depends_on = [aws_organizations_delegated_administrator.sso]
 
-  repository_name                = var.repository_name
-  branch_name                    = var.branch_name
-  use_code_connection            = var.use_code_connection
-  account_lifecyle_events_source = "AFT"
-  tags                           = local.tags
+  repository_name                 = var.repository_name
+  branch_name                     = var.branch_name
+  use_code_connection             = var.use_code_connection
+  account_lifecycle_events_source = "AFT"
+  tags                            = local.tags
 }
 
 

--- a/patterns/multi-region-basic/aft-account-customizations/IDENTITY/terraform/main.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/IDENTITY/terraform/main.tf
@@ -35,11 +35,11 @@ module "aws_ps_pipeline" {
   }
   depends_on = [aws_organizations_delegated_administrator.sso]
 
-  repository_name                = var.repository_name
-  branch_name                    = var.branch_name
-  use_code_connection            = var.use_code_connection
-  account_lifecyle_events_source = "AFT"
-  tags                           = local.tags
+  repository_name                 = var.repository_name
+  branch_name                     = var.branch_name
+  use_code_connection             = var.use_code_connection
+  account_lifecycle_events_source = "AFT"
+  tags                            = local.tags
 }
 
 ########################################

--- a/patterns/single-region-basic/aft-account-customizations/IDENTITY/terraform/main.tf
+++ b/patterns/single-region-basic/aft-account-customizations/IDENTITY/terraform/main.tf
@@ -35,11 +35,11 @@ module "aws_ps_pipeline" {
   }
   depends_on = [aws_organizations_delegated_administrator.sso]
 
-  repository_name                = var.repository_name
-  branch_name                    = var.branch_name
-  use_code_connection            = var.use_code_connection
-  account_lifecyle_events_source = "AFT"
-  tags                           = local.tags
+  repository_name                 = var.repository_name
+  branch_name                     = var.branch_name
+  use_code_connection             = var.use_code_connection
+  account_lifecycle_events_source = "AFT"
+  tags                            = local.tags
 }
 
 


### PR DESCRIPTION
- Added option None to account_lifecycle_events_source variable
- Fixed typo in account_lifecycle_events_source variable