### PR TITLE
fix: Added EC2 bastion host AMI owner to avoid terraform warning

### DIFF
--- a/modules/compute/ec2_bastion/data.tf
+++ b/modules/compute/ec2_bastion/data.tf
@@ -13,13 +13,10 @@ data "aws_kms_alias" "current" {
 
 data "aws_ami" "amazon_linux" {
   most_recent = true
+  owners      = ["amazon"]
 
   filter {
     name   = "name"
     values = ["amzn2-ami-hvm-*-x86_64-gp2"]
-  }
-  filter {
-    name   = "owner-alias"
-    values = ["amazon"]
   }
 }


### PR DESCRIPTION
Added EC2 bastion host AMI owner to avoid terraform warning: "Fix Most Recent Image Not Filtered...consider filtering by owner or image ID to avoid this possibility."