### PR TITLE
fix: Security Hub standards arn moved to variables

### DIFF
--- a/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/README.md
+++ b/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/README.md
@@ -4,7 +4,8 @@ This Terraform code is designed to set up additional AWS resources in the Contro
 
 The following resources will be deployed by this solution (not limited to those below):
 
-- AWS S3 Bucket for VPC Flow Logs
+- Amazon GuardDuty
+- AWS Security Hub
 
 For more information, see the [Centralized Logs](https://awslabs.github.io/aft-blueprints/architectures/centralized-logs) architecture page.
 
@@ -36,6 +37,7 @@ Update the `variable.auto.tfvars` file with the corresponding values for:
 ### AWS Security Hub
 
 - **securityhub_control_finding_generator:** Inform if you want to turn on consolidated control findings (SECURITY_CONTROL).
+- **securityhub_enabled_standard_arns:** Inform the list of security standards ARNs that you want to enable. Be sure to use your primary region when entering the ARN.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/main.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/main.tf
@@ -100,12 +100,9 @@ module "securityhub_default_policy" {
   source     = "../../common/modules/security/securityhub_policy"
   depends_on = [module.securityhub]
 
-  name            = "default-policy"
-  description     = "Default policy for organization"
-  service_enabled = true
-  enabled_standard_arns = [
-    "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0",
-    "arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/3.0.0"
-  ]
-  association_targets = [data.aws_organizations_organization.org.roots[0].id]
+  name                  = "default-policy"
+  description           = "Default policy for organization"
+  service_enabled       = true
+  enabled_standard_arns = var.securityhub_enabled_standard_arns
+  association_targets   = [data.aws_organizations_organization.org.roots[0].id]
 }

--- a/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/variables.auto.tfvars
+++ b/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/variables.auto.tfvars
@@ -3,3 +3,7 @@
 
 guardduty_auto_enable_organization_members = "ALL"
 securityhub_control_finding_generator      = "SECURITY_CONTROL"
+securityhub_enabled_standard_arns = [
+  "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0",
+  "arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/3.0.0"
+]

--- a/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/variables.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/variables.tf
@@ -20,3 +20,10 @@ variable "securityhub_control_finding_generator" {
     error_message = "Valid values are: SECURITY_CONTROL, STANDARD_CONTROL."
   }
 }
+
+variable "securityhub_enabled_standard_arns" {
+  description = "List of AWS Security Hub standard ARNs to enable."
+  type        = list(string)
+  default     = []
+}
+

--- a/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/README.md
+++ b/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/README.md
@@ -4,7 +4,8 @@ This Terraform code is designed to set up additional AWS resources in the Contro
 
 The following resources will be deployed by this solution (not limited to those below):
 
-- AWS S3 Bucket for VPC Flow Logs
+- Amazon GuardDuty
+- AWS Security Hub
 
 For more information, see the [Centralized Logs](https://awslabs.github.io/aft-blueprints/architectures/centralized-logs) architecture page.
 
@@ -36,6 +37,7 @@ Update the `variable.auto.tfvars` file with the corresponding values for:
 ### AWS Security Hub
 
 - **securityhub_control_finding_generator:** Inform if you want to turn on consolidated control findings (SECURITY_CONTROL).
+- **securityhub_enabled_standard_arns:** Inform the list of security standards ARNs that you want to enable. Be sure to use your primary region when entering the ARN.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
@@ -100,12 +100,9 @@ module "securityhub_default_policy" {
   source     = "../../common/modules/security/securityhub_policy"
   depends_on = [module.securityhub]
 
-  name            = "default-policy"
-  description     = "Default policy for organization"
-  service_enabled = true
-  enabled_standard_arns = [
-    "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0",
-    "arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/3.0.0"
-  ]
-  association_targets = [data.aws_organizations_organization.org.roots[0].id]
+  name                  = "default-policy"
+  description           = "Default policy for organization"
+  service_enabled       = true
+  enabled_standard_arns = var.securityhub_enabled_standard_arns
+  association_targets   = [data.aws_organizations_organization.org.roots[0].id]
 }

--- a/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/variables.auto.tfvars
+++ b/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/variables.auto.tfvars
@@ -3,3 +3,7 @@
 
 guardduty_auto_enable_organization_members = "ALL"
 securityhub_control_finding_generator      = "SECURITY_CONTROL"
+securityhub_enabled_standard_arns = [
+  "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0",
+  "arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/3.0.0"
+]

--- a/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/variables.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/variables.tf
@@ -20,3 +20,9 @@ variable "securityhub_control_finding_generator" {
     error_message = "Valid values are: SECURITY_CONTROL, STANDARD_CONTROL."
   }
 }
+
+variable "securityhub_enabled_standard_arns" {
+  description = "List of AWS Security Hub standard ARNs to enable."
+  type        = list(string)
+  default     = []
+}

--- a/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/README.md
+++ b/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/README.md
@@ -4,7 +4,8 @@ This Terraform code is designed to set up additional AWS resources in the Contro
 
 The following resources will be deployed by this solution (not limited to those below):
 
-- AWS S3 Bucket for VPC Flow Logs
+- Amazon GuardDuty
+- AWS Security Hub
 
 For more information, see the [Centralized Logs](https://awslabs.github.io/aft-blueprints/architectures/centralized-logs) architecture page.
 
@@ -32,6 +33,7 @@ Update the `variable.auto.tfvars` file with the corresponding values for:
 ### AWS Security Hub
 
 - **securityhub_control_finding_generator:** Inform if you want to turn on consolidated control findings (SECURITY_CONTROL).
+- **securityhub_enabled_standard_arns:** Inform the list of security standards ARNs that you want to enable. Be sure to use your primary region when entering the ARN.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
+++ b/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
@@ -81,12 +81,9 @@ module "securityhub_default_policy" {
   source     = "../../common/modules/security/securityhub_policy"
   depends_on = [module.securityhub]
 
-  name            = "default-policy"
-  description     = "Default policy for organization"
-  service_enabled = true
-  enabled_standard_arns = [
-    "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0",
-    "arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/3.0.0"
-  ]
-  association_targets = [data.aws_organizations_organization.org.roots[0].id]
+  name                  = "default-policy"
+  description           = "Default policy for organization"
+  service_enabled       = true
+  enabled_standard_arns = var.securityhub_enabled_standard_arns
+  association_targets   = [data.aws_organizations_organization.org.roots[0].id]
 }

--- a/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/variables.auto.tfvars
+++ b/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/variables.auto.tfvars
@@ -3,3 +3,7 @@
 
 guardduty_auto_enable_organization_members = "ALL"
 securityhub_control_finding_generator      = "SECURITY_CONTROL"
+securityhub_enabled_standard_arns = [
+  "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0",
+  "arn:aws:securityhub:us-east-1::standards/cis-aws-foundations-benchmark/v/3.0.0"
+]

--- a/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/variables.tf
+++ b/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/variables.tf
@@ -20,3 +20,10 @@ variable "securityhub_control_finding_generator" {
     error_message = "Valid values are: SECURITY_CONTROL, STANDARD_CONTROL."
   }
 }
+
+variable "securityhub_enabled_standard_arns" {
+  description = "List of AWS Security Hub standard ARNs to enable."
+  type        = list(string)
+  default     = []
+}
+


### PR DESCRIPTION
- Security Hub standards ARN list moved to variables on SECURITY account customizations for all patterns.
- Documentation updated

Close #14