### PR TITLE
Fix:Adding ORG provider to data to grab ORG ROOT ID

### DIFF
--- a/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/data.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/data.tf
@@ -5,6 +5,10 @@ data "aws_caller_identity" "current" {}
 
 data "aws_organizations_organization" "org" {}
 
+data "aws_organizations_organization" "root_ou" {
+  provider = aws.org-management-primary
+}
+
 data "aws_region" "secondary" {
   provider = aws.secondary
 }

--- a/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/main.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/main.tf
@@ -104,5 +104,5 @@ module "securityhub_default_policy" {
   description           = "Default policy for organization"
   service_enabled       = true
   enabled_standard_arns = var.securityhub_enabled_standard_arns
-  association_targets   = [data.aws_organizations_organization.org.roots[0].id]
+  association_targets   = [data.aws_organizations_organization.root_ou.roots[0].id]
 }

--- a/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/data.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/data.tf
@@ -5,6 +5,10 @@ data "aws_caller_identity" "current" {}
 
 data "aws_organizations_organization" "org" {}
 
+data "aws_organizations_organization" "root_ou" {
+  provider = aws.org-management-primary
+}
+
 data "aws_region" "secondary" {
   provider = aws.secondary
 }

--- a/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
@@ -104,5 +104,5 @@ module "securityhub_default_policy" {
   description           = "Default policy for organization"
   service_enabled       = true
   enabled_standard_arns = var.securityhub_enabled_standard_arns
-  association_targets   = [data.aws_organizations_organization.org.roots[0].id]
+  association_targets   = [data.aws_organizations_organization.root_ou.roots[0].id]
 }

--- a/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/data.tf
+++ b/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/data.tf
@@ -4,3 +4,7 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_organizations_organization" "org" {}
+
+data "aws_organizations_organization" "root_ou" {
+  provider = aws.org-management-primary
+}

--- a/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
+++ b/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
@@ -85,5 +85,5 @@ module "securityhub_default_policy" {
   description           = "Default policy for organization"
   service_enabled       = true
   enabled_standard_arns = var.securityhub_enabled_standard_arns
-  association_targets   = [data.aws_organizations_organization.org.roots[0].id]
+  association_targets   = [data.aws_organizations_organization.root_ou.roots[0].id]
 }


### PR DESCRIPTION
*Issue #17 , if available:*

*Description of changes:* Adding the ORG Management Provider to give the right permission to grab the ORG ROOT ID


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
