### PR TITLE
BugFix: Removing unnecessary DNS provider for a second region

### DIFF
--- a/patterns/single-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/dns.tf
+++ b/patterns/single-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/dns.tf
@@ -20,14 +20,3 @@ module "phz_association_1" {
 
   phz_id = module.phz[0].zone_id
 }
-
-module "phz_association_2" {
-  source = "../../../common/modules/dns/route53_phz_association"
-  count  = var.phz_name == null ? 0 : 1
-  providers = {
-    aws.dns = aws.dns2
-  }
-
-  phz_id = module.phz[0].zone_id
-}
-

--- a/patterns/single-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/versions.tf
+++ b/patterns/single-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/versions.tf
@@ -10,7 +10,6 @@ terraform {
       configuration_aliases = [
         aws.network,
         aws.dns1,
-        aws.dns2,
       ]
     }
   }

--- a/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/dns.tf
+++ b/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/dns.tf
@@ -20,14 +20,3 @@ module "phz_association_1" {
 
   phz_id = module.phz[0].zone_id
 }
-
-module "phz_association_2" {
-  source = "../../../common/modules/dns/route53_phz_association"
-  count  = var.phz_name == null ? 0 : 1
-  providers = {
-    aws.dns = aws.dns2
-  }
-
-  phz_id = module.phz[0].zone_id
-}
-

--- a/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/versions.tf
+++ b/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/versions.tf
@@ -10,7 +10,6 @@ terraform {
       configuration_aliases = [
         aws.network,
         aws.dns1,
-        aws.dns2,
       ]
     }
   }


### PR DESCRIPTION
*Issue #19 , if available:*

*Description of changes:* 

The code has a not necessary provider for a second region that causes this error:

```
Error: Missing required provider configuration

  on main.tf line 4:
   4: module "primary_region" {

The child module requires an additional configuration for provider
hashicorp/aws, with the local name "aws.dns2".

Refer to the module's documentation to understand the intended purpose of
this additional provider configuration, and then add an entry for aws.dns2 in
the "providers" meta-argument in the module block to choose which provider
configuration the module should use for that purpose.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
