### PR TITLE
Feat: Updated all backend.jinfa files to use the assume_role.role_arn

### DIFF
--- a/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-advanced/aft-account-customizations/BACKUP/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-account-customizations/BACKUP/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-advanced/aft-account-customizations/IDENTITY/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-account-customizations/IDENTITY/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-advanced/aft-account-customizations/LOG_ARCHIVE/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-account-customizations/LOG_ARCHIVE/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-advanced/aft-account-customizations/NETWORK/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-account-customizations/NETWORK/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-account-customizations/SECURITY/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-advanced/aft-account-provisioning-customizations/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-account-provisioning-customizations/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-advanced/aft-account-request/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-account-request/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-advanced/aft-global-customizations/terraform/backend.jinja
+++ b/patterns/multi-region-advanced/aft-global-customizations/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-account-customizations/BACKUP/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-account-customizations/BACKUP/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-account-customizations/IDENTITY/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-account-customizations/IDENTITY/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-account-customizations/LOG_ARCHIVE/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-account-customizations/LOG_ARCHIVE/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-account-customizations/NETWORK/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-account-customizations/NETWORK/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-account-customizations/SECURITY/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-account-provisioning-customizations/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-account-provisioning-customizations/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-account-request/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-account-request/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/multi-region-basic/aft-global-customizations/terraform/backend.jinja
+++ b/patterns/multi-region-basic/aft-global-customizations/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-account-customizations/APP_DEV/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-account-customizations/APP_DEV/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-account-customizations/BACKUP/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-account-customizations/BACKUP/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-account-customizations/IDENTITY/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-account-customizations/IDENTITY/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-account-customizations/LOG_ARCHIVE/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-account-customizations/LOG_ARCHIVE/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-account-customizations/NETWORK/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-account-customizations/NETWORK/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-account-provisioning-customizations/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-account-provisioning-customizations/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-account-request/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-account-request/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}

--- a/patterns/single-region-basic/aft-global-customizations/terraform/backend.jinja
+++ b/patterns/single-region-basic/aft-global-customizations/terraform/backend.jinja
@@ -11,7 +11,9 @@ terraform {
     dynamodb_table = "{{ dynamodb_table }}"
     encrypt        = "true"
     kms_key_id     = "{{ kms_key_id }}"
-    role_arn       = "{{ aft_admin_role_arn }}"
+    assume_role = {
+      role_arn       = "{{ aft_admin_role_arn }}"
+    }
   }
 }
 {% else -%}


### PR DESCRIPTION
- Updated all backend.jinfa files to use the assume_role.role_arn attribute, instead of only role_arn. Which has been deprecated in the latest versions of Terraform .