### PR TITLE
fix: Upgraded AWS provider to allow NO_REGIONS linking mode for SH

### DIFF
--- a/modules/security/securityhub/variables.tf
+++ b/modules/security/securityhub/variables.tf
@@ -4,17 +4,17 @@
 variable "linking_mode" {
   description = "Indicates whether to aggregate findings from all of the available Regions or from a specified list."
   type        = string
-  default     = "SPECIFIED_REGIONS"
+  default     = "NO_REGIONS"
   validation {
-    condition     = contains(["ALL_REGIONS", "SPECIFIED_REGIONS", "ALL_REGIONS_EXCEPT_SPECIFIED"], var.linking_mode)
-    error_message = "Invalid linking mode. Valid values are ALL_REGIONS, SPECIFIED_REGIONS or ALL_REGIONS_EXCEPT_SPECIFIED."
+    condition     = contains(["NO_REGIONS", "ALL_REGIONS", "SPECIFIED_REGIONS", "ALL_REGIONS_EXCEPT_SPECIFIED"], var.linking_mode)
+    error_message = "Invalid linking mode. Valid values are NO_REGIONS, ALL_REGIONS, SPECIFIED_REGIONS or ALL_REGIONS_EXCEPT_SPECIFIED."
   }
 }
 
 variable "specified_regions" {
   description = "List of regions to include or exclude (required if linking_mode is set to ALL_REGIONS_EXCEPT_SPECIFIED or SPECIFIED_REGIONS)."
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "auto_enable_accounts" {

--- a/modules/security/securityhub/versions.tf
+++ b/modules/security/securityhub/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>5.0"
+      version = "~>5.98"
     }
   }
 }

--- a/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
+++ b/patterns/single-region-basic/aft-account-customizations/SECURITY/terraform/main.tf
@@ -41,7 +41,7 @@ module "primary_guardduty" {
 #######   Security Hub delegation    #######
 ############################################
 # aws_securityhub_account is necessary to enable consolidated control findings feature, 
-# as Terraform resources for securityhub organization configuration level don't support set up it.
+# as Terraform resources for securityhub organization configuration level doesn't support setting it up.
 # https://github.com/hashicorp/terraform-provider-aws/issues/30022
 # https://github.com/hashicorp/terraform-provider-aws/pull/30692
 # https://github.com/hashicorp/terraform-provider-aws/issues/39687
@@ -68,8 +68,6 @@ module "securityhub" {
   ]
 
   configuration_type = "CENTRAL"
-  linking_mode       = "SPECIFIED_REGIONS"
-  specified_regions  = []
 }
 
 


### PR DESCRIPTION
- Upgraded AWS provider ([v5.98](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.98.0)) to allow NO_REGIONS linking mode for Security Hub finding aggregator.
- In addition to previous variable change to securityhub_enabled_standard_arns and improved README, to close #13.
