### PR TITLE
chore: Minor changes to ec2_bastion, route_r53_phz_association, vpce and spoke modules

### DIFF
--- a/modules/compute/ec2_bastion/README.md
+++ b/modules/compute/ec2_bastion/README.md
@@ -42,5 +42,7 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| instance\_id | The EC2 instance id |
 <!-- END_TF_DOCS -->

--- a/modules/compute/ec2_bastion/main.tf
+++ b/modules/compute/ec2_bastion/main.tf
@@ -79,7 +79,8 @@ resource "aws_security_group" "bastion" {
 }
 
 resource "aws_iam_role" "bastion_role" {
-  name_prefix = "ec2-${var.identifier}-bastion-role-"
+  name_prefix           = "ec2-${var.identifier}-bastion-role-"
+  force_detach_policies = true
   assume_role_policy = jsonencode(
     {
       Version = "2012-10-17"

--- a/modules/compute/ec2_bastion/outputs.tf
+++ b/modules/compute/ec2_bastion/outputs.tf
@@ -1,0 +1,7 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+output "instance_id" {
+  value       = aws_instance.bastion_linux.id
+  description = "The EC2 instance id"
+}

--- a/modules/dns/route53_phz_association/main.tf
+++ b/modules/dns/route53_phz_association/main.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 resource "aws_route53_zone_association" "phz" {
-  count = var.associate_to_local_vpc == null ? 1 : 0
+  count = var.associate_to_local_vpc == true ? 1 : 0
 
   vpc_id     = var.vpc_id
   vpc_region = var.vpc_region

--- a/modules/network/vpc_shared/README.md
+++ b/modules/network/vpc_shared/README.md
@@ -60,6 +60,7 @@
 | enable\_central\_vpc\_flow\_logs | Should be true to enable centralized vpc flow logs to S3 bucket. | `bool` | `false` | no |
 | enable\_dns\_hostnames | Should be true to enable DNS hostnames in the VPC | `bool` | `true` | no |
 | enable\_vpc\_flow\_logs | Should be true to enable vpc flow logs to a local cloudwatch log group. | `bool` | `true` | no |
+| endpoint\_policies | A map of endpoint policies | `map(any)` | `{}` | no |
 | environment | Environment name. Will be used to define ipam pool and tgw route tables configuration. | `string` | `"shared"` | no |
 | gateway\_endpoints | A list of interface endpoints | `list(string)` | `[]` | no |
 | identifier | VPC identifier. If not entered, a random id will be generated. | `string` | `""` | no |

--- a/modules/network/vpc_shared/modules.tf
+++ b/modules/network/vpc_shared/modules.tf
@@ -30,6 +30,7 @@ module "vpce" {
     route_table_ids = toset(values(aws_route_table.subnets)[*].id)
     services        = var.gateway_endpoints
   }
+  policies = var.endpoint_policies
 }
 
 module "route53_rules_association" {

--- a/modules/network/vpc_shared/variables.tf
+++ b/modules/network/vpc_shared/variables.tf
@@ -169,6 +169,12 @@ variable "gateway_endpoints" {
   default     = []
 }
 
+variable "endpoint_policies" {
+  description = "A map of endpoint policies"
+  type        = map(any)
+  default     = {}
+}
+
 variable "vpc_tags" {
   description = "Additional tags for the VPC"
   type        = map(string)

--- a/modules/network/vpc_spoke/README.md
+++ b/modules/network/vpc_spoke/README.md
@@ -70,6 +70,7 @@
 | enable\_central\_vpc\_flow\_logs | Should be true to enable centralized vpc flow logs to S3 bucket. | `bool` | `false` | no |
 | enable\_dns\_hostnames | Should be true to enable DNS hostnames in the VPC | `bool` | `true` | no |
 | enable\_vpc\_flow\_logs | Should be true to enable vpc flow logs to a local cloudwatch log group. | `bool` | `true` | no |
+| endpoint\_policies | A map of endpoint policies | `map(any)` | `{}` | no |
 | environment | Environment name. Will be used to define ipam pool and tgw route tables configuration. | `string` | n/a | yes |
 | gateway\_endpoints | A list of interface endpoints | `list(string)` | `[]` | no |
 | identifier | VPC identifier. If not entered, a random id will be generated. | `string` | `""` | no |

--- a/modules/network/vpc_spoke/modules.tf
+++ b/modules/network/vpc_spoke/modules.tf
@@ -30,6 +30,7 @@ module "vpce" {
     route_table_ids = toset(concat(values(aws_route_table.private)[*].id, try([aws_route_table.public[0].id], [])))
     services        = var.gateway_endpoints
   }
+  policies = var.endpoint_policies
 }
 
 module "route53_rules_association" {

--- a/modules/network/vpc_spoke/variables.tf
+++ b/modules/network/vpc_spoke/variables.tf
@@ -150,6 +150,12 @@ variable "gateway_endpoints" {
   default     = []
 }
 
+variable "endpoint_policies" {
+  description = "A map of endpoint policies"
+  type        = map(any)
+  default     = {}
+}
+
 variable "private_subnet_tags" {
   description = "Additional tags for private subnets"
   type        = map(string)

--- a/modules/network/vpce/README.md
+++ b/modules/network/vpce/README.md
@@ -34,6 +34,7 @@ No modules.
 | allowed\_cidr | Additional CIDRs to be added in the interface endpoints security group created by the module (when security\_group\_id is not informed). | `list(string)` | `[]` | no |
 | gateway\_endpoints | A list of route tables and gateway endpoints | ```object({ route_table_ids = list(string) services = list(string) })``` | ```{ "route_table_ids": [], "services": [] }``` | no |
 | interface\_endpoints | A list of subnet IDs and interface endpoint service names. For service names use com.amazonaws.<region>.<service> format, or just <service> (e.g. com.amazonaws.us-east-1.ssm or ssm). | ```object({ subnet_ids = list(string) services = list(string) })``` | ```{ "services": [], "subnet_ids": [] }``` | no |
+| policies | A map with endpoint service name (key) and IAM resource policy JSON (value) to be applied to endpoint. For service names use com.amazonaws.<region>.<service> format, or just <service> (e.g. com.amazonaws.us-east-1.ssm or ssm). | `map(any)` | `{}` | no |
 | private\_dns\_enabled | Whether or not to enable private DNS. | `bool` | `true` | no |
 | security\_group\_id | The ID of the security group to be added in the interface endpoints. | `string` | `null` | no |
 | tags | Tags to be applied to all resources. | `map(string)` | `{}` | no |

--- a/modules/network/vpce/main.tf
+++ b/modules/network/vpce/main.tf
@@ -55,24 +55,7 @@ resource "aws_vpc_endpoint" "interface" {
   security_group_ids  = local.create_security_group ? [aws_security_group.endpoints[0].id] : [var.security_group_id]
   subnet_ids          = var.interface_endpoints.subnet_ids
   private_dns_enabled = var.private_dns_enabled
-  policy = each.value == "ssm" || each.value == "com.amazonaws.${var.vpc_region}.ssm" ? jsonencode({
-    Version : "2012-10-17",
-    Statement : [
-      {
-        Sid : "AllowAll",
-        Effect : "Allow",
-        Principal : {
-          AWS : "*"
-        },
-        Action : [
-          "ssm:List*",
-          "ssm:Get*",
-          "ssm:UpdateInstanceInformation*"
-        ],
-        Resource : "*"
-      }
-    ]
-  }) : null
+  policy              = lookup(var.policies, each.value, null)
   tags = merge(
     { "Name" = "${var.vpc_name}-${replace(each.value, ".", "-")}-endpoint" },
     var.tags

--- a/modules/network/vpce/variables.tf
+++ b/modules/network/vpce/variables.tf
@@ -41,18 +41,6 @@ variable "private_dns_enabled" {
   default     = true
 }
 
-variable "interface_endpoints" {
-  description = "A list of subnet IDs and interface endpoint service names. For service names use com.amazonaws.<region>.<service> format, or just <service> (e.g. com.amazonaws.us-east-1.ssm or ssm)."
-  type = object({
-    subnet_ids = list(string)
-    services   = list(string)
-  })
-  default = {
-    subnet_ids = []
-    services   = []
-  }
-}
-
 variable "gateway_endpoints" {
   description = "A list of route tables and gateway endpoints"
   type = object({
@@ -70,6 +58,24 @@ variable "gateway_endpoints" {
     )
     error_message = "The value of services is invalid, it must be one of the following: s3 or dynamodb."
   }
+}
+
+variable "interface_endpoints" {
+  description = "A list of subnet IDs and interface endpoint service names. For service names use com.amazonaws.<region>.<service> format, or just <service> (e.g. com.amazonaws.us-east-1.ssm or ssm)."
+  type = object({
+    subnet_ids = list(string)
+    services   = list(string)
+  })
+  default = {
+    subnet_ids = []
+    services   = []
+  }
+}
+
+variable "policies" {
+  description = "A map with endpoint service name (key) and IAM resource policy JSON (value) to be applied to endpoint. For service names use com.amazonaws.<region>.<service> format, or just <service> (e.g. com.amazonaws.us-east-1.ssm or ssm)."
+  type        = map(any)
+  default     = {}
 }
 
 variable "tags" {

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/blueprint/data.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/blueprint/data.tf
@@ -2,11 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 data "aws_region" "current" {}
-
-data "aws_route53_zone" "phz" {
-  count      = var.phz_name == null ? 0 : 1
-  depends_on = [module.phz]
-
-  name         = var.phz_name
-  private_zone = true
-}

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/blueprint/dns.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/blueprint/dns.tf
@@ -18,10 +18,9 @@ module "phz_association" {
     aws.dns = aws.network
   }
 
-  phz_id                       = data.aws_route53_zone.phz[0].zone_id
-  vpc_id                       = module.vpc[0].vpc_id
+  phz_id                       = var.phz_id == null ? module.phz[0].zone_id : var.phz_id
+  vpc_id                       = var.create_phz ? null : try(module.vpc[0].vpc_id, null)
   vpc_region                   = data.aws_region.current.name
-  associate_to_local_vpc       = var.create_phz ? false : true
+  associate_to_local_vpc       = var.create_phz ? false : var.vpc == null ? false : true
   associate_to_central_dns_vpc = true
 }
-

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/blueprint/outputs.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/blueprint/outputs.tf
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+output "vpc_id" {
+  value = try(module.vpc[0].vpc_id, null)
+}
+
+output "phz_id" {
+  value = try(module.phz[0].zone_id, null)
+}
+
+output "instance_id" {
+  value = try(module.bastion[0].instance_id, null)
+}

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/blueprint/variables.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/blueprint/variables.tf
@@ -15,7 +15,13 @@ variable "create_phz" {
 
 variable "phz_name" {
   type        = string
-  description = "Route 53 Private Hosted Zone name to create and/or associate to the centralized DNS VPC."
+  description = "Route 53 Private Hosted Zone name to create and/or associate to the centralized DNS VPC. [inform it if you are creating the PHZ]"
+  default     = null
+}
+
+variable "phz_id" {
+  type        = string
+  description = "Route 53 Private Hosted Zone Id to associate to the centralized DNS VPC. [use it when you are NOT creating the PHZ]"
   default     = null
 }
 

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/main.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_DEV/terraform/main.tf
@@ -26,6 +26,7 @@ module "secondary_region" {
   }
 
   phz_name = local.phz_name
+  phz_id   = try(module.primary_region[0].phz_id, null) #reusing Route 53 PHZ from the primary region, as it is a global resource
   vpc      = local.vpc
   tags     = local.tags
 }

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/blueprint/data.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/blueprint/data.tf
@@ -2,11 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 data "aws_region" "current" {}
-
-data "aws_route53_zone" "phz" {
-  count      = var.phz_name == null ? 0 : 1
-  depends_on = [module.phz]
-
-  name         = var.phz_name
-  private_zone = true
-}

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/blueprint/dns.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/blueprint/dns.tf
@@ -18,10 +18,9 @@ module "phz_association" {
     aws.dns = aws.network
   }
 
-  phz_id                       = data.aws_route53_zone.phz[0].zone_id
-  vpc_id                       = module.vpc[0].vpc_id
+  phz_id                       = var.phz_id == null ? module.phz[0].zone_id : var.phz_id
+  vpc_id                       = var.create_phz ? null : try(module.vpc[0].vpc_id, null)
   vpc_region                   = data.aws_region.current.name
-  associate_to_local_vpc       = var.create_phz ? false : true
+  associate_to_local_vpc       = var.create_phz ? false : var.vpc == null ? false : true
   associate_to_central_dns_vpc = true
 }
-

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/blueprint/outputs.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/blueprint/outputs.tf
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+output "vpc_id" {
+  value = try(module.vpc[0].vpc_id, null)
+}
+
+output "phz_id" {
+  value = try(module.phz[0].zone_id, null)
+}
+
+output "instance_id" {
+  value = try(module.bastion[0].instance_id, null)
+}

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/blueprint/variables.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/blueprint/variables.tf
@@ -15,7 +15,13 @@ variable "create_phz" {
 
 variable "phz_name" {
   type        = string
-  description = "Route 53 Private Hosted Zone name to create and/or associate to the centralized DNS VPC."
+  description = "Route 53 Private Hosted Zone name to create and/or associate to the centralized DNS VPC. [inform it if you are creating the PHZ]"
+  default     = null
+}
+
+variable "phz_id" {
+  type        = string
+  description = "Route 53 Private Hosted Zone Id to associate to the centralized DNS VPC. [use it when you are NOT creating the PHZ]"
   default     = null
 }
 

--- a/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/main.tf
+++ b/patterns/multi-region-advanced/aft-account-customizations/APP_PROD/terraform/main.tf
@@ -28,6 +28,7 @@ module "secondary_region" {
   }
 
   phz_name          = local.phz_name
+  phz_id            = try(module.primary_region[0].phz_id, null) #reusing Route 53 PHZ from the primary region, as it is a global resource
   vpc               = local.vpc
   backup_account_id = data.aws_ssm_parameter.backup_account_id.value
   tags              = local.tags

--- a/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/data.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/data.tf
@@ -3,10 +3,3 @@
 
 data "aws_region" "current" {}
 
-data "aws_route53_zone" "phz" {
-  count      = var.phz_name == null ? 0 : 1
-  depends_on = [module.phz]
-
-  name         = var.phz_name
-  private_zone = true
-}

--- a/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/dns.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/dns.tf
@@ -18,10 +18,9 @@ module "phz_association" {
     aws.dns = aws.network
   }
 
-  phz_id                       = data.aws_route53_zone.phz[0].zone_id
-  vpc_id                       = module.vpc[0].vpc_id
+  phz_id                       = var.phz_id == null ? module.phz[0].zone_id : var.phz_id
+  vpc_id                       = var.create_phz ? null : try(module.vpc[0].vpc_id, null)
   vpc_region                   = data.aws_region.current.name
-  associate_to_local_vpc       = var.create_phz ? false : true
+  associate_to_local_vpc       = var.create_phz ? false : var.vpc == null ? false : true
   associate_to_central_dns_vpc = true
 }
-

--- a/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/outputs.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/outputs.tf
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+output "vpc_id" {
+  value = try(module.vpc[0].vpc_id, null)
+}
+
+output "phz_id" {
+  value = try(module.phz[0].zone_id, null)
+}
+
+output "instance_id" {
+  value = try(module.bastion[0].instance_id, null)
+}

--- a/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/variables.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/variables.tf
@@ -15,7 +15,13 @@ variable "create_phz" {
 
 variable "phz_name" {
   type        = string
-  description = "Route 53 Private Hosted Zone name to create and/or associate to the centralized DNS VPC."
+  description = "Route 53 Private Hosted Zone name to create and/or associate to the centralized DNS VPC. [inform it if you are creating the PHZ]"
+  default     = null
+}
+
+variable "phz_id" {
+  type        = string
+  description = "Route 53 Private Hosted Zone Id to associate to the centralized DNS VPC. [use it when you are NOT creating the PHZ]"
   default     = null
 }
 

--- a/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/main.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_DEV/terraform/main.tf
@@ -26,6 +26,7 @@ module "secondary_region" {
   }
 
   phz_name = local.phz_name
+  phz_id   = try(module.primary_region[0].phz_id, null) #reusing Route 53 PHZ from the primary region, as it is a global resource
   vpc      = local.vpc
   tags     = local.tags
 }

--- a/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/data.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/data.tf
@@ -2,11 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 data "aws_region" "current" {}
-
-data "aws_route53_zone" "phz" {
-  count      = var.phz_name == null ? 0 : 1
-  depends_on = [module.phz]
-
-  name         = var.phz_name
-  private_zone = true
-}

--- a/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/dns.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/dns.tf
@@ -18,10 +18,9 @@ module "phz_association" {
     aws.dns = aws.network
   }
 
-  phz_id                       = data.aws_route53_zone.phz[0].zone_id
-  vpc_id                       = module.vpc[0].vpc_id
+  phz_id                       = var.phz_id == null ? module.phz[0].zone_id : var.phz_id
+  vpc_id                       = var.create_phz ? null : try(module.vpc[0].vpc_id, null)
   vpc_region                   = data.aws_region.current.name
-  associate_to_local_vpc       = var.create_phz ? false : true
+  associate_to_local_vpc       = var.create_phz ? false : var.vpc == null ? false : true
   associate_to_central_dns_vpc = true
 }
-

--- a/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/outputs.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/outputs.tf
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+output "vpc_id" {
+  value = try(module.vpc[0].vpc_id, null)
+}
+
+output "phz_id" {
+  value = try(module.phz[0].zone_id, null)
+}
+
+output "instance_id" {
+  value = try(module.bastion[0].instance_id, null)
+}

--- a/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/variables.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/variables.tf
@@ -15,7 +15,13 @@ variable "create_phz" {
 
 variable "phz_name" {
   type        = string
-  description = "Route 53 Private Hosted Zone name to create and/or associate to the centralized DNS VPC."
+  description = "Route 53 Private Hosted Zone name to create and/or associate to the centralized DNS VPC. [inform it if you are creating the PHZ]"
+  default     = null
+}
+
+variable "phz_id" {
+  type        = string
+  description = "Route 53 Private Hosted Zone Id to associate to the centralized DNS VPC. [use it when you are NOT creating the PHZ]"
   default     = null
 }
 

--- a/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/main.tf
+++ b/patterns/multi-region-basic/aft-account-customizations/APP_PROD/terraform/main.tf
@@ -28,6 +28,7 @@ module "secondary_region" {
   }
 
   phz_name          = local.phz_name
+  phz_id            = try(module.primary_region[0].phz_id, null) #reusing Route 53 PHZ from the primary region, as it is a global resource
   vpc               = local.vpc
   backup_account_id = data.aws_ssm_parameter.backup_account_id.value
   tags              = local.tags

--- a/patterns/single-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/outputs.tf
+++ b/patterns/single-region-basic/aft-account-customizations/APP_DEV/terraform/blueprint/outputs.tf
@@ -1,0 +1,10 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+output "vpc_id" {
+  value = try(module.vpc[0].vpc_id, null)
+}
+
+output "instance_id" {
+  value = try(module.bastion[0].instance_id, null)
+}

--- a/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/README.md
+++ b/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/README.md
@@ -64,7 +64,9 @@ custom_fields = {
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >=1.5.0 |
 
 ## Providers
 

--- a/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/outputs.tf
+++ b/patterns/single-region-basic/aft-account-customizations/APP_PROD/terraform/blueprint/outputs.tf
@@ -1,0 +1,10 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+output "vpc_id" {
+  value = try(module.vpc[0].vpc_id, null)
+}
+
+output "instance_id" {
+  value = try(module.bastion[0].instance_id, null)
+}


### PR DESCRIPTION
- Adding `force_detach_policies` to bastion host instance profile role.
- Fixing `aws_route53_zone_association` condition on Route 53 PHZ association module.
- Removing unnecessary SSM VPC endpoint policy on VPC Endpoints module.
- Adding `policies` variable VPC Endpoints module.
- Adding outputs to spoke's blueprints (APP_DEV and APP_PROD).
- Fixing dependencies between regions to associate local PHZ with DNS VPCs.
- Adding `endpoint_policies` variable to spoke and shared VPC modules.