### PR TITLE
fix: Removed external CDN references in mkdocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,9 +110,6 @@ extra:
       - reject
       - manage
 
-extra_javascript:
-  - https://cdn.jsdelivr.net/npm/@glidejs/glide
-
 nav:
   - Overview: index.md
   - Getting started: getting-started.md


### PR DESCRIPTION
- Removed external references to CDN in mkdocs configuration
- The glide library was not used and was removed to avoid the use of external references